### PR TITLE
New columns in leavehistory table

### DIFF
--- a/app/Http/Controllers/Logins/Security/LeaveController.php
+++ b/app/Http/Controllers/Logins/Security/LeaveController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\Storage;
 
 class LeaveController extends Controller
 {
@@ -38,7 +39,14 @@ class LeaveController extends Controller
             if($existingLeave)
             {
                 $intime = Carbon::now()->setTimezone('Asia/Kolkata');
-                DB::table('leavehistory')->where('id',$existingLeave->id)->update(['intime' => $intime]);
+                DB::table('leavehistory')->where('id',$existingLeave->id)->update(['intime' => $intime, 'inregistration' => $security_name, 'ingate' => $gate]);
+                if($student && $student->barcode)
+                {
+                    // Delete the Barcode Image
+                    Storage::disk('public')->delete($student->barcode);
+                    // Delete the row from leavereq_histories table
+                    DB::table('leavereq_histories')->where('id',$student->id)->delete();
+                }
                 return redirect()->back()->with('success',"Leave Closed for $rollno at $intime");
             }
             else{
@@ -50,9 +58,11 @@ class LeaveController extends Controller
                     'placeofvisit' => $student->placeofvisit,
                     'purpose' => $student->purpose,
                     'outtime' => $outtime,
+                    'outregistration' => $security_name,
+                    'outgate' => $gate,
                     'intime' => null,
-                    'security' => $security_name,
-                    'gate' => $gate,
+                    'inregistration' => null,
+                    'ingate' => null,
                 ]);
                 return redirect()->back()->with('success',"Leave Started for $rollno at $outtime");
             }
@@ -88,7 +98,14 @@ class LeaveController extends Controller
             if($existingLeave)
             {
                 $intime = Carbon::now()->setTimezone('Asia/Kolkata');
-                DB::table('leavehistory')->where('id',$existingLeave->id)->update(['intime' => $intime]);
+                DB::table('leavehistory')->where('id',$existingLeave->id)->update(['intime' => $intime, 'inregistration' => $security_name, 'ingate' => $gate]);
+                if($student && $student->barcode)
+                {
+                    // Delete the Barcode Image
+                    Storage::disk('public')->delete($student->barcode);
+                    // Delete the row from leavereq_histories table
+                    DB::table('leavereq_histories')->where('id',$student->id)->delete();
+                }
                 return redirect()->back()->with('success',"Leave Closed for $rollno at $intime");
             }
             else{
@@ -100,9 +117,11 @@ class LeaveController extends Controller
                     'placeofvisit' => $student->placeofvisit,
                     'purpose' => $student->purpose,
                     'outtime' => $outtime,
+                    'outregistration' => $security_name,
+                    'outgate' => $gate,
                     'intime' => null,
-                    'Security' => $security_name,
-                    'gate' => $gate,
+                    'inregistration' => null,
+                    'ingate' => null,
                 ]);
                 return redirect()->back()->with('success',"Leave Started for $rollno at $outtime");
             }

--- a/database/migrations/2024_05_28_083010_leavehistory.php
+++ b/database/migrations/2024_05_28_083010_leavehistory.php
@@ -23,8 +23,10 @@ return new class extends Migration
             $table->string('purpose');
             $table->dateTime('outtime');
             $table->dateTime('intime')->nullable();
-            $table->string('Security');
-            $table->string('gate');
+            $table->string('outregistration');
+            $table->string('outgate');
+            $table->string('inregistration')->nullable();
+            $table->string('ingate')->nullable();
             $table->timestamps();
         });
     }

--- a/resources/views/Logins/SecurityPages/Leave/LeaveHistory.blade.php
+++ b/resources/views/Logins/SecurityPages/Leave/LeaveHistory.blade.php
@@ -47,8 +47,10 @@
                         <th>Phone No</th>
                         <th>Place of Visit</th>
                         <th>Purpose</th>
-                        <th>Security</th>
-                        <th>Gate</th>
+                        <th>Out-Registration</th>
+                        <th>Out-Gate</th>
+                        <th>In-Registration</th>
+                        <th>In-Gate</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -61,8 +63,10 @@
                         <td>{{$leave->phoneno}}</td>
                         <td>{{$leave->placeofvisit}}</td>
                         <td>{{$leave->purpose}}</td>
-                        <td>{{$leave->Security}}</td>
-                        <td>{{$leave->gate}}</td>
+                        <td>{{$leave->outregistration}}</td>
+                        <td>{{$leave->outgate}}</td>
+                        <td>{{$leave->inregistration}}</td>
+                        <td>{{$leave->ingate}}</td>
                     </tr>
                     @endforeach
                 </tbody>

--- a/resources/views/Logins/StudentPages/OutingHistory.blade.php
+++ b/resources/views/Logins/StudentPages/OutingHistory.blade.php
@@ -43,6 +43,7 @@
                     <th>Roll No</th>
                     <th>Out Date and Time</th>
                     <th>In Date and Time</th>
+                    <th>Registration by</th>
                 </tr>
             </thead>
             <tbody>
@@ -51,6 +52,7 @@
                     <td>{{$outing->rollno}}</td>
                     <td>{{date('d/m/Y h:i a',strtotime($outing->outtime))}}</td>
                     <td>{{date('d/m/Y h:i a',strtotime($outing->intime))}}</td>
+                    <td>{{$outing->security}}</td>
                 </tr>
                 @endforeach
             </tbody>


### PR DESCRIPTION
Added the columns outregistration ( name of the security person who registered the out-leave for the student), outgate, inregistration, and ingate to store information about the names of the securities performing the registration operation and the gate where the operation was performed. Deleting the barcodes after the in time is set for a leave history and deleting the leave request from the leavereq_histories table too at the same time. 